### PR TITLE
Correct behavior when running under chefspec

### DIFF
--- a/libraries/blacklist.rb
+++ b/libraries/blacklist.rb
@@ -127,9 +127,11 @@ end
 
 class Chef
   class Node
-    alias_method :pre_blacklist_save, :save
+    alias pre_blacklist_save save unless method_defined?(:pre_blacklist_save)
 
     def save
+      return pre_blacklist_save unless self["blacklist"]
+
       Chef::Log.info("Blacklisting node attributes")
       blacklist = self["blacklist"].to_hash
 


### PR DESCRIPTION
Apparently chefspec does not initialize correctly the node object and
self['blacklist'] is nil instead of empty.
This only happen in chefspec when using several examples.

To avoid a "stack too deep" error we also alias save method only once.
